### PR TITLE
Rework contacts sync (closes #1)

### DIFF
--- a/LocalContacts/LocalContactsApp.swift
+++ b/LocalContacts/LocalContactsApp.swift
@@ -35,7 +35,7 @@ struct LocalContactsApp: App {
             case .updated(let data):
                 if let contact = store.contacts.first(where: { $0.localContactsID == data.localContactsID }),
                    contact.conflictState == nil {
-                    contact.conflictState = .externalEdit
+                    contact.conflictState = .externalEdit(data)
                 }
             case .deleted(let localContactsID):
                 if let contact = store.contacts.first(where: { $0.localContactsID == localContactsID }),

--- a/LocalContacts/Models/Contact.swift
+++ b/LocalContacts/Models/Contact.swift
@@ -171,6 +171,16 @@ struct PostalAddress: Sendable {
 }
 
 enum ConflictState: Sendable {
-    case externalEdit
+    case externalEdit(CNSyncService.CNContactData)
     case externalDelete
+
+    var isExternalEdit: Bool {
+        if case .externalEdit = self { return true }
+        return false
+    }
+
+    var externalData: CNSyncService.CNContactData? {
+        if case .externalEdit(let data) = self { return data }
+        return nil
+    }
 }

--- a/LocalContacts/Services/CNSyncService.swift
+++ b/LocalContacts/Services/CNSyncService.swift
@@ -2,7 +2,7 @@ import Contacts
 import Foundation
 
 actor CNSyncService {
-    private let store = CNContactStore()
+    nonisolated(unsafe) private let store = CNContactStore()
     private let containerNameKey = "LocalContacts"
     private let containerIDKey = "LocalContacts_ContainerID"
     private let historyTokenKey = "LocalContacts_ChangeHistoryToken"

--- a/LocalContacts/Services/CNSyncService.swift
+++ b/LocalContacts/Services/CNSyncService.swift
@@ -42,14 +42,21 @@ actor CNSyncService {
 
     // MARK: - Container & Group
 
-    private func defaultContainerID() -> String {
-        (try? store.defaultContainerIdentifier()) ?? ""
+    /// Prefer the local (on-device / "iPhone") container so the LocalContacts
+    /// group doesn't land in a remote account like Google Contacts.
+    /// Falls back to the default container when no local container exists.
+    private func localContainerID() -> String {
+        if let containers = try? store.containers(matching: nil),
+           let local = containers.first(where: { $0.type == .local }) {
+            return local.identifier
+        }
+        return (try? store.defaultContainerIdentifier()) ?? ""
     }
 
     /// Find or create the single "LocalContacts" group in the default container.
     /// Also cleans up any duplicate groups from prior bugs.
     private func resolveGroup() throws -> (containerID: String, group: CNGroup) {
-        let containerID = defaultContainerID()
+        let containerID = localContainerID()
         let predicate = CNGroup.predicateForGroupsInContainer(withIdentifier: containerID)
         let groups = try store.groups(matching: predicate)
         let matches = groups.filter { $0.name == containerNameKey }
@@ -135,7 +142,7 @@ actor CNSyncService {
     func fullReconciliation(contacts: [Contact]) async throws {
         guard authorizationStatus == .authorized else { return }
 
-        let containerID = defaultContainerID()
+        let containerID = localContainerID()
 
         // 1. Find ALL "LocalContacts" groups and delete their member contacts + the groups themselves
         let predicate = CNGroup.predicateForGroupsInContainer(withIdentifier: containerID)

--- a/LocalContacts/Services/ContactsStore.swift
+++ b/LocalContacts/Services/ContactsStore.swift
@@ -7,9 +7,11 @@ final class ContactsStore {
     var contacts: [Contact] = []
     var searchText: String = ""
     var selectedTag: String?
+    var showConflictsOnly = false
     var folderURL: URL?
     var isLoading = false
     var errorMessage: String?
+    var lastSyncedAt: Date?
 
     private let parser = VCardParser()
     private let writer = VCardWriter()
@@ -32,7 +34,9 @@ final class ContactsStore {
     var filteredContacts: [Contact] {
         var result = contacts
 
-        if let tag = selectedTag {
+        if showConflictsOnly {
+            result = result.filter { $0.conflictState != nil }
+        } else if let tag = selectedTag {
             result = result.filter { $0.categories.contains(tag) }
         }
 
@@ -128,6 +132,7 @@ final class ContactsStore {
             errorMessage = "Failed to read folder: \(error.localizedDescription)"
         }
 
+        lastSyncedAt = Date()
         isLoading = false
     }
 

--- a/LocalContacts/Views/ConflictResolutionSheet.swift
+++ b/LocalContacts/Views/ConflictResolutionSheet.swift
@@ -7,101 +7,370 @@ struct ConflictResolutionSheet: View {
 
     var body: some View {
         NavigationStack {
-            VStack(spacing: 24) {
-                Image(systemName: conflictIcon)
-                    .font(.system(size: 48))
-                    .foregroundStyle(.orange)
+            if let data = contact.conflictState?.externalData {
+                ConflictDiffView(contact: contact, externalData: data, store: store, dismiss: dismiss)
+            } else {
+                // External delete — simple UI
+                deletionView
+            }
+        }
+    }
 
-                Text(conflictTitle)
-                    .font(.title3.bold())
-                    .multilineTextAlignment(.center)
+    private var deletionView: some View {
+        VStack(spacing: 24) {
+            Image(systemName: "trash.circle.fill")
+                .font(.system(size: 48))
+                .foregroundStyle(.orange)
 
-                Text(conflictMessage)
-                    .foregroundStyle(.secondary)
-                    .multilineTextAlignment(.center)
-                    .padding(.horizontal, 24)
+            Text("External Deletion Detected")
+                .font(.title3.bold())
+                .multilineTextAlignment(.center)
 
-                VStack(spacing: 12) {
-                    Button {
-                        keepLocalVersion()
-                    } label: {
-                        Label("Keep LocalContacts Version", systemImage: "doc.badge.arrow.up")
-                            .frame(maxWidth: .infinity)
-                    }
-                    .buttonStyle(.borderedProminent)
-
-                    if contact.conflictState == .externalEdit {
-                        Button {
-                            importExternalChanges()
-                        } label: {
-                            Label("Import External Changes", systemImage: "arrow.down.doc")
-                                .frame(maxWidth: .infinity)
-                        }
-                        .buttonStyle(.bordered)
-                    }
-                }
-                .controlSize(.large)
+            Text("\(contact.displayName) was deleted outside LocalContacts. You can re-push the local version or accept the deletion.")
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
                 .padding(.horizontal, 24)
 
-                Spacer()
+            VStack(spacing: 12) {
+                Button {
+                    contact.conflictState = nil
+                    Task {
+                        try? await store.syncService.pushContact(contact)
+                        dismiss()
+                    }
+                } label: {
+                    Label("Re-Push to Contacts", systemImage: "arrow.up.doc")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+
+                Button(role: .destructive) {
+                    Task {
+                        try? await store.delete(contact)
+                        dismiss()
+                    }
+                } label: {
+                    Label("Accept Deletion", systemImage: "trash")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
             }
-            .padding(.top, 32)
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button("Dismiss") { dismiss() }
+            .controlSize(.large)
+            .padding(.horizontal, 24)
+
+            Spacer()
+        }
+        .padding(.top, 32)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Dismiss") { dismiss() }
+            }
+        }
+    }
+}
+
+// MARK: - Diff View
+
+private struct ConflictDiffView: View {
+    let contact: Contact
+    let externalData: CNSyncService.CNContactData
+    let store: ContactsStore
+    let dismiss: DismissAction
+
+    @State private var selections: [String: FieldSource] = [:]
+
+    enum FieldSource {
+        case local, apple
+    }
+
+    var body: some View {
+        List {
+            Section {
+                Text("\(contact.displayName) was edited in Apple Contacts. Choose which version to keep for each field.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .listRowBackground(Color.clear)
+            }
+
+            ForEach(diffs) { diff in
+                Section(diff.label) {
+                    FieldRow(
+                        key: diff.key,
+                        localValue: diff.localValue,
+                        appleValue: diff.appleValue,
+                        selection: selections[diff.key],
+                        onSelect: { source in
+                            selections[diff.key] = source
+                        }
+                    )
+                }
+            }
+
+            if !identicalFields.isEmpty {
+                Section {
+                    DisclosureGroup("Identical Fields") {
+                        ForEach(identicalFields, id: \.self) { name in
+                            Text(name)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .foregroundStyle(.secondary)
                 }
             }
         }
-        .presentationDetents([.medium])
-    }
-
-    private var conflictIcon: String {
-        switch contact.conflictState {
-        case .externalEdit: "pencil.circle.fill"
-        case .externalDelete: "trash.circle.fill"
-        case nil: "questionmark.circle"
+        .navigationTitle("Resolve Conflict")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Dismiss") { dismiss() }
+            }
+        }
+        .safeAreaInset(edge: .bottom) {
+            bottomBar
+        }
+        .onAppear {
+            // Default all selections to local
+            for diff in diffs {
+                selections[diff.key] = .local
+            }
         }
     }
 
-    private var conflictTitle: String {
-        switch contact.conflictState {
-        case .externalEdit: "External Edit Detected"
-        case .externalDelete: "External Deletion Detected"
-        case nil: "No Conflict"
+    private var bottomBar: some View {
+        VStack(spacing: 8) {
+            HStack(spacing: 12) {
+                Button("Keep All Local") {
+                    for diff in diffs { selections[diff.key] = .local }
+                }
+                .buttonStyle(.bordered)
+                .tint(.accentColor)
+
+                Button("Keep All Apple") {
+                    for diff in diffs { selections[diff.key] = .apple }
+                }
+                .buttonStyle(.bordered)
+                .tint(.orange)
+            }
+
+            Button {
+                applyMerge()
+            } label: {
+                Text("Apply")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
         }
+        .padding()
+        .background(.ultraThinMaterial)
     }
 
-    private var conflictMessage: String {
-        switch contact.conflictState {
-        case .externalEdit:
-            "\(contact.displayName) was edited outside LocalContacts. Choose which version to keep."
-        case .externalDelete:
-            "\(contact.displayName) was deleted outside LocalContacts. You can re-push the local version or accept the deletion."
-        case nil:
-            ""
-        }
+    // MARK: - Diff Computation
+
+    struct FieldDiff: Identifiable {
+        let key: String
+        let label: String
+        let localValue: String
+        let appleValue: String
+        var id: String { key }
     }
 
-    private func keepLocalVersion() {
+    private var diffs: [FieldDiff] {
+        var result: [FieldDiff] = []
+
+        func addIfDifferent(_ key: String, _ label: String, _ local: String, _ apple: String) {
+            let l = local.trimmingCharacters(in: .whitespacesAndNewlines)
+            let a = apple.trimmingCharacters(in: .whitespacesAndNewlines)
+            if l != a {
+                result.append(FieldDiff(key: key, label: label, localValue: l.isEmpty ? "(empty)" : l, appleValue: a.isEmpty ? "(empty)" : a))
+            }
+        }
+
+        // Name fields
+        let localFullName = [contact.namePrefix, contact.givenName, contact.middleName, contact.familyName, contact.nameSuffix]
+            .filter { !$0.isEmpty }.joined(separator: " ")
+        let appleFullName = [externalData.namePrefix, externalData.givenName, externalData.middleName, externalData.familyName, externalData.nameSuffix]
+            .filter { !$0.isEmpty }.joined(separator: " ")
+        addIfDifferent("name", "Name", localFullName, appleFullName)
+
+        addIfDifferent("organization", "Organization", contact.organization, externalData.organization)
+        addIfDifferent("jobTitle", "Job Title", contact.jobTitle, externalData.jobTitle)
+        addIfDifferent("nickname", "Nickname", contact.nickname, externalData.nickname)
+
+        // Phone numbers
+        let localPhones = contact.phoneNumbers.map { "\($0.label): \($0.value)" }.sorted().joined(separator: "\n")
+        let applePhones = externalData.phoneNumbers.map { "\($0.label): \($0.value)" }.sorted().joined(separator: "\n")
+        addIfDifferent("phones", "Phone Numbers", localPhones, applePhones)
+
+        // Emails
+        let localEmails = contact.emailAddresses.map { "\($0.label): \($0.value)" }.sorted().joined(separator: "\n")
+        let appleEmails = externalData.emailAddresses.map { "\($0.label): \($0.value)" }.sorted().joined(separator: "\n")
+        addIfDifferent("emails", "Email Addresses", localEmails, appleEmails)
+
+        // URLs
+        let localURLs = contact.urls.map { "\($0.label): \($0.value)" }.sorted().joined(separator: "\n")
+        let appleURLs = externalData.urls.map { "\($0.label): \($0.value)" }.sorted().joined(separator: "\n")
+        addIfDifferent("urls", "URLs", localURLs, appleURLs)
+
+        // Postal addresses
+        let localAddrs = contact.postalAddresses.map { "\($0.label): \($0.value.formatted)" }.sorted().joined(separator: "\n\n")
+        let appleAddrs = externalData.postalAddresses.map { addr in
+            let formatted = [addr.street, addr.city, [addr.state, addr.postalCode].filter { !$0.isEmpty }.joined(separator: " "), addr.country]
+                .filter { !$0.isEmpty }.joined(separator: "\n")
+            return "\(addr.label): \(formatted)"
+        }.sorted().joined(separator: "\n\n")
+        addIfDifferent("addresses", "Addresses", localAddrs, appleAddrs)
+
+        // Birthday
+        let localBday = contact.birthday.map { formatBirthday($0) } ?? ""
+        let appleBday = externalData.birthday.map { formatBirthday($0) } ?? ""
+        addIfDifferent("birthday", "Birthday", localBday, appleBday)
+
+        return result
+    }
+
+    private var identicalFields: [String] {
+        let allFieldKeys: [(String, String)] = [
+            ("name", "Name"), ("organization", "Organization"), ("jobTitle", "Job Title"),
+            ("nickname", "Nickname"), ("phones", "Phone Numbers"), ("emails", "Email Addresses"),
+            ("urls", "URLs"), ("addresses", "Addresses"), ("birthday", "Birthday"),
+        ]
+        let diffKeys = Set(diffs.map(\.key))
+        return allFieldKeys.filter { !diffKeys.contains($0.0) }.map(\.1)
+    }
+
+    private func formatBirthday(_ dc: DateComponents) -> String {
+        var parts: [String] = []
+        if let year = dc.year { parts.append("\(year)") }
+        if let month = dc.month { parts.append(String(format: "%02d", month)) }
+        if let day = dc.day { parts.append(String(format: "%02d", day)) }
+        return parts.joined(separator: "-")
+    }
+
+    // MARK: - Apply Merge
+
+    private func applyMerge() {
+        for diff in diffs {
+            let useApple = selections[diff.key] == .apple
+            switch diff.key {
+            case "name":
+                if useApple {
+                    contact.givenName = externalData.givenName
+                    contact.familyName = externalData.familyName
+                    contact.middleName = externalData.middleName
+                    contact.namePrefix = externalData.namePrefix
+                    contact.nameSuffix = externalData.nameSuffix
+                    contact.fullName = [externalData.givenName, externalData.middleName, externalData.familyName]
+                        .filter { !$0.isEmpty }.joined(separator: " ")
+                }
+            case "organization":
+                if useApple { contact.organization = externalData.organization }
+            case "jobTitle":
+                if useApple { contact.jobTitle = externalData.jobTitle }
+            case "nickname":
+                if useApple { contact.nickname = externalData.nickname }
+            case "phones":
+                if useApple {
+                    contact.phoneNumbers = externalData.phoneNumbers.map {
+                        LabeledValue(label: $0.label, value: $0.value)
+                    }
+                }
+            case "emails":
+                if useApple {
+                    contact.emailAddresses = externalData.emailAddresses.map {
+                        LabeledValue(label: $0.label, value: $0.value)
+                    }
+                }
+            case "urls":
+                if useApple {
+                    contact.urls = externalData.urls.map {
+                        LabeledValue(label: $0.label, value: $0.value)
+                    }
+                }
+            case "addresses":
+                if useApple {
+                    contact.postalAddresses = externalData.postalAddresses.map {
+                        LabeledValue(label: $0.label, value: PostalAddress(
+                            street: $0.street, city: $0.city, state: $0.state,
+                            postalCode: $0.postalCode, country: $0.country
+                        ))
+                    }
+                }
+            case "birthday":
+                if useApple { contact.birthday = externalData.birthday }
+            default:
+                break
+            }
+        }
+
+        // Import photo from Apple if available (photos aren't diffed)
+        // Keep local photo unless Apple version exists and local is nil
+        if contact.photoData == nil, let applePhoto = externalData.imageData {
+            contact.photoData = applePhoto
+        }
+
         contact.conflictState = nil
+
         Task {
+            try? await store.save(contact)
             try? await store.syncService.pushContact(contact)
             dismiss()
         }
     }
+}
 
-    private func importExternalChanges() {
-        Task {
-            if let data = await store.syncService.fetchCNContactData(localContactsID: contact.localContactsID) {
-                try? await store.applyExternalData(data, to: contact)
-                // Re-push to CN so both sides are consistent
-                try? await store.syncService.pushContact(contact)
-            } else {
-                // Couldn't fetch — just clear the flag
-                contact.conflictState = nil
+// MARK: - Field Row
+
+private struct FieldRow: View {
+    let key: String
+    let localValue: String
+    let appleValue: String
+    let selection: ConflictDiffView.FieldSource?
+    let onSelect: (ConflictDiffView.FieldSource) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Button { onSelect(.local) } label: {
+                HStack(alignment: .top, spacing: 10) {
+                    Image(systemName: selection == .local ? "checkmark.circle.fill" : "circle")
+                        .foregroundStyle(selection == .local ? Color.accentColor : .secondary)
+                        .font(.title3)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("LocalContacts")
+                            .font(.caption.weight(.medium))
+                            .foregroundStyle(.secondary)
+                        Text(localValue)
+                            .font(.body)
+                            .foregroundStyle(.primary)
+                    }
+                    Spacer()
+                }
+                .contentShape(Rectangle())
             }
-            dismiss()
+            .buttonStyle(.plain)
+
+            Divider()
+
+            Button { onSelect(.apple) } label: {
+                HStack(alignment: .top, spacing: 10) {
+                    Image(systemName: selection == .apple ? "checkmark.circle.fill" : "circle")
+                        .foregroundStyle(selection == .apple ? .orange : .secondary)
+                        .font(.title3)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Apple Contacts")
+                            .font(.caption.weight(.medium))
+                            .foregroundStyle(.orange)
+                        Text(appleValue)
+                            .font(.body)
+                            .foregroundStyle(.primary)
+                    }
+                    Spacer()
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
         }
+        .padding(.vertical, 4)
     }
 }

--- a/LocalContacts/Views/ContactDetailView.swift
+++ b/LocalContacts/Views/ContactDetailView.swift
@@ -55,13 +55,13 @@ struct ContactDetailView: View {
                         showConflictSheet = true
                     } label: {
                         HStack(spacing: 12) {
-                            Image(systemName: contact.conflictState == .externalEdit
+                            Image(systemName: contact.conflictState?.isExternalEdit == true
                                   ? "pencil.circle.fill" : "trash.circle.fill")
                                 .font(.title3)
                                 .foregroundStyle(.orange)
 
                             VStack(alignment: .leading, spacing: 2) {
-                                Text(contact.conflictState == .externalEdit
+                                Text(contact.conflictState?.isExternalEdit == true
                                      ? "External Edit Detected"
                                      : "External Deletion Detected")
                                     .font(.subheadline.weight(.medium))

--- a/LocalContacts/Views/ContactEditView.swift
+++ b/LocalContacts/Views/ContactEditView.swift
@@ -37,8 +37,9 @@ struct ContactEditView: View {
                     Spacer()
                     VStack(spacing: 8) {
                         AvatarView(contact: contact, size: 80)
+                        let hasPhoto = contact.photoData != nil
                         PhotosPicker(selection: $selectedPhoto, matching: .images) {
-                            Text(contact.photoData != nil ? "Change Photo" : "Add Photo")
+                            Text(hasPhoto ? "Change Photo" : "Add Photo")
                                 .font(.subheadline)
                         }
                         if contact.photoData != nil {

--- a/LocalContacts/Views/ContactListView.swift
+++ b/LocalContacts/Views/ContactListView.swift
@@ -73,7 +73,7 @@ struct ContactListView: View {
 
     private var contactList: some View {
         VStack(spacing: 0) {
-            if !store.allTags.isEmpty {
+            if !store.allTags.isEmpty || store.hasConflicts {
                 TagFilterBar()
             }
 
@@ -187,15 +187,30 @@ struct TagFilterBar: View {
 
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: 8) {
-                TagChip(title: "All", isSelected: store.selectedTag == nil) {
+                TagChip(title: "All", isSelected: store.selectedTag == nil && !store.showConflictsOnly) {
                     store.selectedTag = nil
+                    store.showConflictsOnly = false
                 }
+
+                if store.hasConflicts {
+                    let count = store.contacts.filter { $0.conflictState != nil }.count
+                    TagChip(
+                        title: "Conflicts (\(count))",
+                        isSelected: store.showConflictsOnly,
+                        tint: .orange
+                    ) {
+                        store.showConflictsOnly.toggle()
+                        if store.showConflictsOnly { store.selectedTag = nil }
+                    }
+                }
+
                 ForEach(store.allTags, id: \.tag) { tagInfo in
                     TagChip(
                         title: "\(tagInfo.tag) (\(tagInfo.count))",
                         isSelected: store.selectedTag == tagInfo.tag
                     ) {
                         store.selectedTag = store.selectedTag == tagInfo.tag ? nil : tagInfo.tag
+                        store.showConflictsOnly = false
                     }
                 }
             }
@@ -208,6 +223,7 @@ struct TagFilterBar: View {
 struct TagChip: View {
     let title: String
     let isSelected: Bool
+    var tint: Color = .accentColor
     let action: () -> Void
 
     var body: some View {
@@ -216,7 +232,7 @@ struct TagChip: View {
                 .font(.subheadline)
                 .padding(.horizontal, 12)
                 .padding(.vertical, 6)
-                .background(isSelected ? Color.accentColor : Color(.systemGray5), in: Capsule())
+                .background(isSelected ? tint : Color(.systemGray5), in: Capsule())
                 .foregroundStyle(isSelected ? .white : .primary)
         }
         .buttonStyle(.plain)

--- a/LocalContacts/Views/SettingsView.swift
+++ b/LocalContacts/Views/SettingsView.swift
@@ -7,6 +7,8 @@ struct SettingsView: View {
     @State private var showFolderPicker = false
     @State private var showOverwriteConfirmation = false
     @State private var contactsAuthStatus: CNAuthorizationStatus = CNContactStore.authorizationStatus(for: .contacts)
+    @AppStorage("hasSeenSyncInfo") private var hasSeenSyncInfo = false
+    @State private var syncInfoExpanded = false
 
     var body: some View {
         NavigationStack {
@@ -28,6 +30,13 @@ struct SettingsView: View {
                     Button("Reload Contacts") {
                         Task { await store.loadContacts() }
                     }
+
+                    if let lastSync = store.lastSyncedAt {
+                        LabeledContent("Last Synced") {
+                            Text(lastSync, style: .relative)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
                 }
 
                 // Contacts Sync
@@ -37,7 +46,17 @@ struct SettingsView: View {
                         Label("Contacts access granted", systemImage: "checkmark.circle.fill")
                             .foregroundStyle(.green)
 
-                        Button("Force Overwrite Contacts App") {
+                        DisclosureGroup("About Contacts Sync", isExpanded: $syncInfoExpanded) {
+                            VStack(alignment: .leading, spacing: 12) {
+                                Text("Local .vcf files are the source of truth. Changes made in Apple Contacts are detected as conflicts for you to review.")
+                                Text("When creating contacts in Apple Contacts, you must manually add them to the \"LocalContacts\" list at the bottom of the new contact creation or edit screen.")
+                                Text("Photos may not round-trip perfectly due to re-encoding by Apple Contacts.")
+                            }
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        }
+
+                        Button("Force Overwrite LocalContacts List in Contacts") {
                             showOverwriteConfirmation = true
                         }
 
@@ -96,7 +115,13 @@ struct SettingsView: View {
                     Button("Done") { dismiss() }
                 }
             }
-            .confirmationDialog("Force Overwrite", isPresented: $showOverwriteConfirmation, titleVisibility: .visible) {
+            .onAppear {
+                if !hasSeenSyncInfo {
+                    syncInfoExpanded = true
+                    hasSeenSyncInfo = true
+                }
+            }
+            .confirmationDialog("Force Overwrite LocalContacts List", isPresented: $showOverwriteConfirmation, titleVisibility: .visible) {
                 Button("Overwrite", role: .destructive) {
                     Task {
                         try? await store.syncService.fullReconciliation(contacts: store.contacts)
@@ -104,9 +129,9 @@ struct SettingsView: View {
                 }
             } message: {
                 if store.hasConflicts {
-                    Text("This will delete all contacts in the LocalContacts group and replace them with the local .vcf versions. \(store.contacts.filter { $0.conflictState != nil }.count) unresolved conflict(s) will be lost.")
+                    Text("This will delete all contacts in the LocalContacts list in Apple Contacts and replace them with the local .vcf versions. \(store.contacts.filter { $0.conflictState != nil }.count) unresolved conflict(s) will be lost.")
                 } else {
-                    Text("This will delete all contacts in the LocalContacts group and replace them with the local .vcf versions.")
+                    Text("This will delete all contacts in the LocalContacts list in Apple Contacts and replace them with the local .vcf versions.")
                 }
             }
             .sheet(isPresented: $showFolderPicker) {


### PR DESCRIPTION
## Summary
- **Field-by-field conflict diff view**: replaces the two-button modal with an inline diff showing each changed field (name, phone, email, etc.) with per-field radio buttons to cherry-pick from local or Apple version, plus "Keep All Local" / "Keep All Apple" quick actions
- **Conflicts filter chip**: orange "Conflicts (N)" chip in the main list tag filter bar, mutually exclusive with tag selection
- **Local container targeting**: LocalContacts group now targets the on-device ("iPhone") container instead of the default container, preventing it from landing in a remote account like Google Contacts
- **Sync info section**: inline DisclosureGroup in Settings > Contacts Integration explaining sync limitations (manual list assignment, .vcf source of truth, photo re-encoding); auto-expanded on first launch
- **Renamed overwrite button**: "Force Overwrite Contacts App" renamed to "Force Overwrite LocalContacts List in Contacts"
- **Last synced timestamp**: relative timestamp shown in Settings > Contacts Folder after "Reload Contacts"

## Test plan
- [ ] Edit a contact in Apple Contacts, reopen app, verify diff view shows field-level differences
- [ ] Merge individual fields from each side, verify saved result is correct
- [ ] Verify "Conflicts" chip appears in tag bar when conflicts exist, filters correctly
- [ ] Check LocalContacts group is created in "iPhone" container (Settings > Contacts > Groups)
- [ ] Verify "About Contacts Sync" disclosure auto-expands on first launch, stays collapsed after
- [ ] Verify "Last Synced" timestamp updates after reload
- [ ] Verify external deletion conflict still shows simple re-push/accept UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
