### PR TITLE
Design rework: glass UI, bulk select, tag mgmt, bug fixes

### DIFF
--- a/LocalContacts/Services/ContactsStore.swift
+++ b/LocalContacts/Services/ContactsStore.swift
@@ -10,6 +10,7 @@ final class ContactsStore {
     var showConflictsOnly = false
     var folderURL: URL?
     var isLoading = false
+    var isSuppressingReload = false
     var errorMessage: String?
     var lastSyncedAt: Date?
 
@@ -44,6 +45,8 @@ final class ContactsStore {
             let query = searchText.lowercased()
             result = result.filter { contact in
                 contact.displayName.lowercased().contains(query)
+                || contact.organization.lowercased().contains(query)
+                || contact.jobTitle.lowercased().contains(query)
                 || contact.phoneNumbers.contains { $0.value.contains(query) }
                 || contact.emailAddresses.contains { $0.value.lowercased().contains(query) }
             }
@@ -91,6 +94,7 @@ final class ContactsStore {
 
     func loadContacts() async {
         guard let url = folderURL else { return }
+        guard !isSuppressingReload else { return }
         if contacts.isEmpty { isLoading = true }
         errorMessage = nil
 
@@ -182,6 +186,60 @@ final class ContactsStore {
 
         // Also remove from CNContactStore
         try? await syncService.deleteContact(localContactsID: contact.localContactsID)
+    }
+
+    // MARK: - Tag Management
+
+    func renameTag(_ oldName: String, to newName: String) async throws {
+        let trimmed = newName.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty, trimmed != oldName else { return }
+
+        for contact in contacts {
+            if let index = contact.categories.firstIndex(of: oldName) {
+                contact.categories[index] = trimmed
+                // Deduplicate if new name already existed on this contact
+                var seen = Set<String>()
+                contact.categories = contact.categories.filter { seen.insert($0).inserted }
+                try await save(contact)
+            }
+        }
+
+        if selectedTag == oldName {
+            selectedTag = trimmed
+        }
+    }
+
+    func deleteTag(_ tagName: String) async throws {
+        for contact in contacts {
+            if contact.categories.contains(tagName) {
+                contact.categories.removeAll { $0 == tagName }
+                try await save(contact)
+            }
+        }
+
+        if selectedTag == tagName {
+            selectedTag = nil
+        }
+    }
+
+    // MARK: - Bulk Operations
+
+    func deleteMultiple(_ contactIDs: Set<String>) async throws {
+        for id in contactIDs {
+            if let contact = contacts.first(where: { $0.localContactsID == id }) {
+                try await delete(contact)
+            }
+        }
+    }
+
+    func assignTag(_ tag: String, to contactIDs: Set<String>) async throws {
+        for id in contactIDs {
+            if let contact = contacts.first(where: { $0.localContactsID == id }),
+               !contact.categories.contains(tag) {
+                contact.categories.append(tag)
+                try await save(contact)
+            }
+        }
     }
 
     // MARK: - Import External Changes

--- a/LocalContacts/Views/ContactDetailView.swift
+++ b/LocalContacts/Views/ContactDetailView.swift
@@ -202,6 +202,9 @@ struct ContactDetailView: View {
                 ContactEditView(contact: contact.copy(), isNew: false)
             }
         }
+        .onChange(of: showEdit) { _, isEditing in
+            store.isSuppressingReload = isEditing
+        }
         .sheet(isPresented: $showConflictSheet) {
             ConflictResolutionSheet(contact: contact)
         }

--- a/LocalContacts/Views/ContactListView.swift
+++ b/LocalContacts/Views/ContactListView.swift
@@ -4,6 +4,10 @@ struct ContactListView: View {
     @Environment(ContactsStore.self) private var store
     @State private var showSettings = false
     @State private var showAddContact = false
+    @State private var isSelecting = false
+    @State private var selectedContactIDs: Set<String> = []
+    @State private var showBulkTagPicker = false
+    @State private var showBulkDeleteConfirmation = false
 
     var body: some View {
         @Bindable var store = store
@@ -19,20 +23,34 @@ struct ContactListView: View {
                 }
             }
             .navigationTitle("Contacts")
-            .searchable(text: $store.searchText, prompt: "Name, phone, or email")
+            .searchable(text: $store.searchText, prompt: "Name, company, phone, or email")
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
-                    Button {
-                        showSettings = true
-                    } label: {
-                        Image(systemName: "gear")
+                    HStack {
+                        Button {
+                            showSettings = true
+                        } label: {
+                            Image(systemName: "gear")
+                        }
+                        if !store.contacts.isEmpty {
+                            Button(isSelecting ? "Done" : "Select") {
+                                withAnimation {
+                                    isSelecting.toggle()
+                                    if !isSelecting {
+                                        selectedContactIDs.removeAll()
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
                 ToolbarItem(placement: .topBarTrailing) {
-                    Button {
-                        showAddContact = true
-                    } label: {
-                        Image(systemName: "plus")
+                    if !isSelecting {
+                        Button {
+                            showAddContact = true
+                        } label: {
+                            Image(systemName: "plus")
+                        }
                     }
                 }
             }
@@ -44,9 +62,14 @@ struct ContactListView: View {
                     ContactEditView(contact: Contact(), isNew: true)
                 }
             }
+            .onChange(of: showAddContact) { _, isAdding in
+                store.isSuppressingReload = isAdding
+            }
             .refreshable {
                 await store.loadContacts()
             }
+            .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
+            .toolbarBackground(.visible, for: .navigationBar)
             .alert("Error", isPresented: .init(
                 get: { store.errorMessage != nil },
                 set: { if !$0 { store.errorMessage = nil } }
@@ -77,21 +100,31 @@ struct ContactListView: View {
                 TagFilterBar()
             }
 
-            List {
+            List(selection: isSelecting ? $selectedContactIDs : nil) {
                 ForEach(store.groupedContacts, id: \.letter) { group in
                     Section(group.letter) {
                         ForEach(group.contacts) { contact in
-                            NavigationLink(value: contact.id) {
+                            if isSelecting {
                                 ContactCard(contact: contact)
+                                    .tag(contact.localContactsID)
+                            } else {
+                                NavigationLink(value: contact.localContactsID) {
+                                    ContactCard(contact: contact)
+                                }
                             }
                         }
                     }
                 }
             }
             .listStyle(.insetGrouped)
-            .navigationDestination(for: UUID.self) { contactID in
-                if let contact = store.contacts.first(where: { $0.id == contactID }) {
+            .environment(\.editMode, isSelecting ? .constant(.active) : .constant(.inactive))
+            .navigationDestination(for: String.self) { contactID in
+                if let contact = store.contacts.first(where: { $0.localContactsID == contactID }) {
                     ContactDetailView(contact: contact)
+                } else {
+                    ContentUnavailableView("Contact Not Found",
+                        systemImage: "person.crop.circle.badge.xmark",
+                        description: Text("This contact may have been deleted."))
                 }
             }
             .overlay {
@@ -99,6 +132,65 @@ struct ContactListView: View {
                     ContentUnavailableView.search(text: store.searchText)
                 }
             }
+
+            if isSelecting && !selectedContactIDs.isEmpty {
+                bulkActionBar
+            }
+        }
+        .sheet(isPresented: $showBulkTagPicker) {
+            BulkTagPickerView(selectedContactIDs: selectedContactIDs) {
+                withAnimation {
+                    isSelecting = false
+                    selectedContactIDs.removeAll()
+                }
+            }
+        }
+        .confirmationDialog(
+            "Delete \(selectedContactIDs.count) Contacts",
+            isPresented: $showBulkDeleteConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("Delete \(selectedContactIDs.count) Contacts", role: .destructive) {
+                Task {
+                    try? await store.deleteMultiple(selectedContactIDs)
+                    withAnimation {
+                        isSelecting = false
+                        selectedContactIDs.removeAll()
+                    }
+                }
+            }
+        } message: {
+            Text("This will permanently delete the selected contacts and their .vcf files.")
+        }
+    }
+
+    private var bulkActionBar: some View {
+        VStack(spacing: 0) {
+            Divider()
+            HStack(spacing: 24) {
+                Button {
+                    showBulkTagPicker = true
+                } label: {
+                    Label("Tag", systemImage: "tag")
+                }
+
+                Spacer()
+
+                Text("\(selectedContactIDs.count) selected")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+
+                Spacer()
+
+                Button(role: .destructive) {
+                    showBulkDeleteConfirmation = true
+                } label: {
+                    Label("Delete", systemImage: "trash")
+                }
+            }
+            .padding(.horizontal, 20)
+            .padding(.vertical, 12)
+            .background(.bar)
         }
     }
 }
@@ -217,6 +309,7 @@ struct TagFilterBar: View {
             .padding(.horizontal)
             .padding(.vertical, 8)
         }
+        .background(.ultraThinMaterial)
     }
 }
 
@@ -236,5 +329,66 @@ struct TagChip: View {
                 .foregroundStyle(isSelected ? .white : .primary)
         }
         .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Bulk Tag Picker
+
+struct BulkTagPickerView: View {
+    @Environment(ContactsStore.self) private var store
+    @Environment(\.dismiss) private var dismiss
+    let selectedContactIDs: Set<String>
+    let onComplete: () -> Void
+    @State private var newTagName = ""
+
+    var body: some View {
+        NavigationStack {
+            List {
+                if !store.allTags.isEmpty {
+                    Section("Existing Tags") {
+                        ForEach(store.allTags, id: \.tag) { tagInfo in
+                            Button {
+                                applyTag(tagInfo.tag)
+                            } label: {
+                                HStack {
+                                    Text(tagInfo.tag)
+                                        .foregroundStyle(.primary)
+                                    Spacer()
+                                    Text("\(tagInfo.count)")
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                        }
+                    }
+                }
+
+                Section("New Tag") {
+                    HStack {
+                        TextField("Tag name", text: $newTagName)
+                        Button("Apply") {
+                            applyTag(newTagName.trimmingCharacters(in: .whitespaces))
+                        }
+                        .disabled(newTagName.trimmingCharacters(in: .whitespaces).isEmpty)
+                    }
+                }
+            }
+            .navigationTitle("Assign Tag")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+        }
+        .presentationDetents([.medium, .large])
+    }
+
+    private func applyTag(_ tag: String) {
+        guard !tag.isEmpty else { return }
+        Task {
+            try? await store.assignTag(tag, to: selectedContactIDs)
+            dismiss()
+            onComplete()
+        }
     }
 }

--- a/LocalContacts/Views/SettingsView.swift
+++ b/LocalContacts/Views/SettingsView.swift
@@ -94,6 +94,20 @@ struct SettingsView: View {
                     Text("Synced contacts appear under a \"LocalContacts\" group in the Apple Contacts app, enabling caller ID and QuickType suggestions.")
                 }
 
+                // Tag Management
+                Section("Tags") {
+                    NavigationLink {
+                        TagManagementView()
+                    } label: {
+                        LabeledContent {
+                            Text("\(store.allTags.count)")
+                                .foregroundStyle(.secondary)
+                        } label: {
+                            Label("Manage Tags", systemImage: "tag")
+                        }
+                    }
+                }
+
                 // Stats
                 Section("Info") {
                     LabeledContent("Total Contacts", value: "\(store.contacts.count)")
@@ -142,5 +156,82 @@ struct SettingsView: View {
                 }
             }
         }
+    }
+}
+
+// MARK: - Tag Management
+
+struct TagManagementView: View {
+    @Environment(ContactsStore.self) private var store
+    @State private var editingTag: String?
+    @State private var editedName = ""
+    @State private var tagToDelete: String?
+
+    var body: some View {
+        List {
+            if store.allTags.isEmpty {
+                ContentUnavailableView("No Tags",
+                    systemImage: "tag.slash",
+                    description: Text("Tags are created when you assign them to contacts."))
+            } else {
+                ForEach(store.allTags, id: \.tag) { tagInfo in
+                    HStack {
+                        if editingTag == tagInfo.tag {
+                            TextField("Tag name", text: $editedName)
+                                .onSubmit { commitRename(from: tagInfo.tag) }
+                            Button("Save") { commitRename(from: tagInfo.tag) }
+                                .buttonStyle(.borderedProminent)
+                                .controlSize(.small)
+                            Button("Cancel") { editingTag = nil }
+                                .controlSize(.small)
+                        } else {
+                            Text(tagInfo.tag)
+                            Spacer()
+                            Text("\(tagInfo.count) contacts")
+                                .foregroundStyle(.secondary)
+                                .font(.subheadline)
+                        }
+                    }
+                    .swipeActions(edge: .trailing) {
+                        Button(role: .destructive) {
+                            tagToDelete = tagInfo.tag
+                        } label: {
+                            Label("Delete", systemImage: "trash")
+                        }
+                        Button {
+                            editingTag = tagInfo.tag
+                            editedName = tagInfo.tag
+                        } label: {
+                            Label("Rename", systemImage: "pencil")
+                        }
+                        .tint(.orange)
+                    }
+                }
+            }
+        }
+        .navigationTitle("Manage Tags")
+        .navigationBarTitleDisplayMode(.inline)
+        .confirmationDialog("Delete Tag", isPresented: .init(
+            get: { tagToDelete != nil },
+            set: { if !$0 { tagToDelete = nil } }
+        ), titleVisibility: .visible) {
+            Button("Delete", role: .destructive) {
+                if let tag = tagToDelete {
+                    Task { try? await store.deleteTag(tag) }
+                }
+            }
+        } message: {
+            if let tag = tagToDelete {
+                let count = store.allTags.first(where: { $0.tag == tag })?.count ?? 0
+                Text("This will remove \"\(tag)\" from \(count) contact(s).")
+            }
+        }
+    }
+
+    private func commitRename(from oldName: String) {
+        let newName = editedName.trimmingCharacters(in: .whitespaces)
+        guard !newName.isEmpty else { return }
+        editingTag = nil
+        Task { try? await store.renameTag(oldName, to: newName) }
     }
 }


### PR DESCRIPTION
## Summary
Closes #2

- **Glass UI header**: Applied `.ultraThinMaterial` to navigation bar and tag filter bar for native translucent appearance
- **Bulk select mode**: Select/Done toggle in toolbar with bulk delete and bulk tag assignment via bottom action bar
- **Tag management**: New "Manage Tags" screen in Settings with swipe-to-rename and swipe-to-delete (with confirmation showing affected contact count)
- **Blank screen bug fix**: Switched navigation from ephemeral `UUID` to stable `localContactsID`, added reload suppression during editing, and a "Contact Not Found" fallback
- **Search organization**: Extended search to include organization name and job title

## Test plan
- [ ] Search a company name — matching contacts should appear
- [ ] Scroll the contact list — nav bar and tag bar should show translucent blur
- [ ] Open a contact, switch away from the app and back (triggers sync), verify the detail view still renders
- [ ] Settings > Manage Tags > swipe to rename a tag, verify it updates on all contacts
- [ ] Settings > Manage Tags > swipe to delete a tag, confirm dialog shows correct count
- [ ] Tap Select, pick multiple contacts, tap Tag — assign an existing or new tag
- [ ] Tap Select, pick multiple contacts, tap Delete — confirm and verify deletion
- [ ] Verify build succeeds with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)