### PR TITLE
Refactor logging to use os.Logger and separate test workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v4
 
@@ -19,21 +19,6 @@ jobs:
 
       - name: Generate Xcode project
         run: xcodegen
-
-      - name: Run tests
-        run: |
-          xcodebuild test \
-            -project LocalContacts.xcodeproj \
-            -scheme LocalContacts \
-            -destination "platform=iOS Simulator,name=iPhone 16,OS=latest" \
-            -resultBundlePath build/TestResults.xcresult
-
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: test-results
-          path: build/TestResults.xcresult
 
       - name: Build
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: macos-26

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,61 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Show toolchain
+        run: |
+          xcodebuild -version
+          xcrun simctl list devices available iPhone
+
+      - name: Install XcodeGen
+        run: brew install xcodegen
+
+      - name: Generate Xcode project
+        run: xcodegen
+
+      - name: Pick a simulator
+        id: pick
+        run: |
+          # Prefer the newest iPhone simulator that's pre-installed on the runner.
+          NAME=$(xcrun simctl list devices available -j \
+            | jq -r '.devices | to_entries
+                     | map(select(.key | contains("iOS")))
+                     | sort_by(.key) | reverse | .[0].value
+                     | map(select(.name | startswith("iPhone")))
+                     | sort_by(.name) | reverse | .[0].name')
+          if [ -z "$NAME" ] || [ "$NAME" = "null" ]; then
+            echo "No iPhone simulator available"; exit 1
+          fi
+          echo "Using simulator: $NAME"
+          echo "device_name=$NAME" >> "$GITHUB_OUTPUT"
+
+      - name: Run tests
+        run: |
+          xcodebuild test \
+            -project LocalContacts.xcodeproj \
+            -scheme LocalContacts \
+            -destination "platform=iOS Simulator,name=${{ steps.pick.outputs.device_name }}" \
+            -resultBundlePath build/TestResults.xcresult \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+          | tee xcodebuild.log
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: build/TestResults.xcresult

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: macos-26
@@ -28,13 +32,17 @@ jobs:
       - name: Pick a simulator
         id: pick
         run: |
-          # Prefer the newest iPhone simulator that's pre-installed on the runner.
+          # Prefer the newest numbered iPhone simulator that's pre-installed
+          # on the runner. Sorting by name lexicographically would put
+          # "iPhone SE" or "iPhone Air" ahead of "iPhone 17", so match the
+          # major version number and sort numerically instead.
           NAME=$(xcrun simctl list devices available -j \
             | jq -r '.devices | to_entries
                      | map(select(.key | contains("iOS")))
                      | sort_by(.key) | reverse | .[0].value
-                     | map(select(.name | startswith("iPhone")))
-                     | sort_by(.name) | reverse | .[0].name')
+                     | map(select(.name | test("^iPhone [0-9]")))
+                     | sort_by(.name | capture("iPhone (?<n>[0-9]+)").n | tonumber)
+                     | reverse | .[0].name')
           if [ -z "$NAME" ] || [ "$NAME" = "null" ]; then
             echo "No iPhone simulator available"; exit 1
           fi
@@ -46,7 +54,7 @@ jobs:
           xcodebuild test \
             -project LocalContacts.xcodeproj \
             -scheme LocalContacts \
-            -destination "platform=iOS Simulator,name=${{ steps.pick.outputs.device_name }}" \
+            -destination "platform=iOS Simulator,name=${{ steps.pick.outputs.device_name }},OS=latest" \
             -resultBundlePath build/TestResults.xcresult \
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_REQUIRED=NO \
@@ -58,4 +66,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: test-results
-          path: build/TestResults.xcresult
+          path: |
+            build/TestResults.xcresult
+            xcodebuild.log

--- a/LocalContacts/LocalContactsApp.swift
+++ b/LocalContacts/LocalContactsApp.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import os
 
 @main
 struct LocalContactsApp: App {
@@ -80,7 +81,7 @@ struct LocalContactsApp: App {
                 forLocalContactsID: contact.localContactsID
             )
         } catch {
-            print("Failed to import external contact: \(error)")
+            Log.sync.error("Failed to import external contact: \(error.localizedDescription, privacy: .public)")
         }
     }
 }

--- a/LocalContacts/Logging.swift
+++ b/LocalContacts/Logging.swift
@@ -1,0 +1,11 @@
+import os
+
+enum Log {
+    private static let subsystem = "localcontacts"
+
+    static let store    = Logger(subsystem: subsystem, category: "store")
+    static let parse    = Logger(subsystem: subsystem, category: "parse")
+    static let bookmark = Logger(subsystem: subsystem, category: "bookmark")
+    static let sync     = Logger(subsystem: subsystem, category: "sync")
+    static let ui       = Logger(subsystem: subsystem, category: "ui")
+}

--- a/LocalContacts/Services/CNSyncService.swift
+++ b/LocalContacts/Services/CNSyncService.swift
@@ -1,5 +1,6 @@
 import Contacts
 import Foundation
+import os
 
 actor CNSyncService {
     nonisolated(unsafe) private let store = CNContactStore()
@@ -31,7 +32,7 @@ actor CNSyncService {
         do {
             return try await store.requestAccess(for: .contacts)
         } catch {
-            print("CNContactStore access error: \(error)")
+            Log.sync.error("CNContactStore access error: \(error.localizedDescription, privacy: .public)")
             return false
         }
     }
@@ -277,7 +278,7 @@ actor CNSyncService {
                 events.append(ChangeEvent(kind: .added(contactData: data)))
             }
         } catch {
-            print("Failed to fetch contacts for change detection: \(error)")
+            Log.sync.error("Failed to fetch contacts for change detection: \(error.localizedDescription, privacy: .public)")
         }
 
         saveHistoryToken()

--- a/LocalContacts/Services/ContactsStore.swift
+++ b/LocalContacts/Services/ContactsStore.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Observation
+import os
 
 @Observable
 @MainActor
@@ -155,11 +156,11 @@ final class ContactsStore {
                         do {
                             try combined.data(using: .utf8)?.write(to: file, options: .atomic)
                         } catch {
-                            print("Warning: Could not migrate IDs in \(file.lastPathComponent): \(error). New IDs may regenerate on next launch, breaking Apple Contacts sync links.")
+                            Log.store.warning("Could not migrate IDs in \(file.lastPathComponent, privacy: .private): \(error.localizedDescription, privacy: .public). New IDs may regenerate on next launch, breaking Apple Contacts sync links.")
                         }
                     }
                 } catch {
-                    print("Warning: Could not parse \(file.lastPathComponent): \(error)")
+                    Log.parse.warning("Could not parse \(file.lastPathComponent, privacy: .private): \(error.localizedDescription, privacy: .public)")
                 }
             }
 

--- a/LocalContacts/Services/ContactsStore.swift
+++ b/LocalContacts/Services/ContactsStore.swift
@@ -156,11 +156,11 @@ final class ContactsStore {
                         do {
                             try combined.data(using: .utf8)?.write(to: file, options: .atomic)
                         } catch {
-                            Log.store.warning("Could not migrate IDs in \(file.lastPathComponent, privacy: .private): \(error.localizedDescription, privacy: .public). New IDs may regenerate on next launch, breaking Apple Contacts sync links.")
+                            Log.store.warning("Could not migrate IDs in \(file.lastPathComponent, privacy: .private): \(error.localizedDescription, privacy: .private). New IDs may regenerate on next launch, breaking Apple Contacts sync links.")
                         }
                     }
                 } catch {
-                    Log.parse.warning("Could not parse \(file.lastPathComponent, privacy: .private): \(error.localizedDescription, privacy: .public)")
+                    Log.parse.warning("Could not parse \(file.lastPathComponent, privacy: .private): \(error.localizedDescription, privacy: .private)")
                 }
             }
 


### PR DESCRIPTION
## Summary
This PR refactors the logging infrastructure to use Apple's unified logging system (`os.Logger`) instead of print statements, and separates the test workflow into its own dedicated GitHub Actions workflow.

## Key Changes

- **New Logging Module**: Added `Logging.swift` with a centralized `Log` enum providing categorized loggers (store, parse, bookmark, sync, ui) using `os.Logger`
- **Replaced print() calls**: Updated all logging statements across the codebase to use the new `Log` API with appropriate privacy levels:
  - `CNSyncService.swift`: Contact store access errors and change detection failures
  - `ContactsStore.swift`: ID migration and file parsing warnings
  - `LocalContactsApp.swift`: External contact import errors
- **Separated CI/CD workflows**: 
  - Moved test execution from `build.yml` to a new dedicated `test.yml` workflow
  - `build.yml` now focuses solely on building and archiving
  - Both workflows run on `macos-26` (updated from `macos-15`)
- **Improved logging practices**: Added privacy annotations to sensitive data (file paths marked as `.private`, error descriptions as `.public`)

## Implementation Details

The new logging system provides:
- Structured logging through `os.Logger` for better integration with Xcode and system logging
- Category-based organization for easier filtering in Console.app
- Privacy-aware logging with appropriate sensitivity levels for different data types
- Cleaner separation of concerns with dedicated test workflow that intelligently selects the newest available iPhone simulator

https://claude.ai/code/session_01UmDacYVaQXnptCk5ThSLv1