### PR TITLE
Settings UX improvements from user feedback

### DIFF
--- a/LocalContacts/Views/SettingsView.swift
+++ b/LocalContacts/Views/SettingsView.swift
@@ -11,7 +11,7 @@ struct SettingsView: View {
     @State private var syncInfoExpanded = false
 
     private var appVersion: String {
-        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "1.0.0"
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "Unknown"
     }
 
     var body: some View {
@@ -250,7 +250,7 @@ struct TagManagementView: View {
         .navigationTitle("Manage Tags")
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
-            ToolbarItem(placement: .navigationBarTrailing) {
+            ToolbarItem(placement: .topBarTrailing) {
                 EditButton()
             }
         }

--- a/LocalContacts/Views/SettingsView.swift
+++ b/LocalContacts/Views/SettingsView.swift
@@ -10,6 +10,10 @@ struct SettingsView: View {
     @AppStorage("hasSeenSyncInfo") private var hasSeenSyncInfo = false
     @State private var syncInfoExpanded = false
 
+    private var appVersion: String {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "1.0.0"
+    }
+
     var body: some View {
         NavigationStack {
             List {
@@ -27,15 +31,15 @@ struct SettingsView: View {
                     }
                     .tint(.primary)
 
-                    Button("Reload Contacts") {
+                    Button {
                         Task { await store.loadContacts() }
+                    } label: {
+                        Label("Reload Contacts", systemImage: "arrow.clockwise")
                     }
+                    .disabled(store.isLoading)
 
                     if let lastSync = store.lastSyncedAt {
-                        LabeledContent("Last Synced") {
-                            Text(lastSync, style: .relative)
-                                .foregroundStyle(.secondary)
-                        }
+                        LabeledContent("Last Synced", value: lastSync, format: .dateTime)
                     }
                 }
 
@@ -133,6 +137,8 @@ struct SettingsView: View {
                                 .foregroundStyle(.orange)
                         }
                     }
+
+                    LabeledContent("Version", value: appVersion)
                 }
             }
             .navigationTitle("Settings")
@@ -176,6 +182,7 @@ struct SettingsView: View {
 
 struct TagManagementView: View {
     @Environment(ContactsStore.self) private var store
+    @Environment(\.editMode) private var editMode
     @State private var editingTag: String?
     @State private var editedName = ""
     @State private var tagToDelete: String?
@@ -200,9 +207,27 @@ struct TagManagementView: View {
                         } else {
                             Text(tagInfo.tag)
                             Spacer()
-                            Text("\(tagInfo.count) contacts")
-                                .foregroundStyle(.secondary)
-                                .font(.subheadline)
+                            if editMode?.wrappedValue.isEditing == true {
+                                HStack(spacing: 16) {
+                                    Button {
+                                        editingTag = tagInfo.tag
+                                        editedName = tagInfo.tag
+                                    } label: {
+                                        Image(systemName: "pencil")
+                                    }
+                                    .tint(.orange)
+                                    Button {
+                                        tagToDelete = tagInfo.tag
+                                    } label: {
+                                        Image(systemName: "trash")
+                                    }
+                                    .tint(.red)
+                                }
+                            } else {
+                                Text("\(tagInfo.count) contacts")
+                                    .foregroundStyle(.secondary)
+                                    .font(.subheadline)
+                            }
                         }
                     }
                     .swipeActions(edge: .trailing) {
@@ -224,6 +249,11 @@ struct TagManagementView: View {
         }
         .navigationTitle("Manage Tags")
         .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                EditButton()
+            }
+        }
         .confirmationDialog("Delete Tag", isPresented: .init(
             get: { tagToDelete != nil },
             set: { if !$0 { tagToDelete = nil } }


### PR DESCRIPTION
## Summary

- **Reload Contacts**: add `arrow.clockwise` icon and disable the button while loading, matching LocalGallery
- **Last Synced**: switch from relative (`"5 minutes ago"`) to full `dateTime` format, matching LocalGallery and LocalMusic
- **Manage Tags**: add an `EditButton` to the toolbar; tapping Edit reveals inline pencil/trash buttons per row — swipe actions remain as a secondary gesture
- **Info section**: add a Version row that reads `CFBundleShortVersionString` from the bundle (currently `1.0.0`), same pattern as LocalGallery

## Test plan

- [ ] Settings → Contacts Folder: "Reload Contacts" shows clockwise arrow icon and greys out while loading
- [ ] Settings → Contacts Folder: "Last Synced" shows a full date/time (e.g. "Apr 28, 2026 at 3:14 PM") after reloading
- [ ] Settings → Tags → Manage Tags: "Edit" button appears in nav bar; tapping it shows pencil and trash icons on each row
- [ ] Manage Tags: pencil opens inline rename field; trash shows confirmation dialog
- [ ] Manage Tags: swipe-left still works for rename/delete
- [ ] Settings → Info: "Version" row shows "1.0.0"

🤖 Generated with [Claude Code](https://claude.com/claude-code)